### PR TITLE
Main content width on large screens

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -102,3 +102,10 @@ html, body {
 	font-size: 0.6em;
 	font-weight: 300;
 }
+
+@media (min-width: 960px) {
+	.well  {
+    max-width: 960px;
+		margin: 15px auto;
+	}
+}


### PR DESCRIPTION
 Currently, the main content width is 100% even on large screens, which makes it hard to read.
![image](https://cloud.githubusercontent.com/assets/13344923/18240099/5b53c5b0-7352-11e6-8497-d2beffee64d3.png)

So I've fixed it.
![image](https://cloud.githubusercontent.com/assets/13344923/18240116/76878452-7352-11e6-827b-11d0157bba07.png)

The navigation width should be the same, but I'll tackle it in a later PR since it required additional changes in the markup.
